### PR TITLE
Fixed I2C Status Bit

### DIFF
--- a/adafruit_mprls.py
+++ b/adafruit_mprls.py
@@ -123,7 +123,7 @@ class MPRLS:
         # check other status bits
         if self._buffer[0] & 0x01:
             raise RuntimeError("Internal math saturation")
-        if self._buffer[0] & 0x04:
+        if self._buffer[2] & 0x01:
             raise RuntimeError("Integrity failure")
 
         # All is good, calculate the PSI and convert to hPA


### PR DESCRIPTION
Memory integrity/error occurs when I2C status bit 2 is 0x01. Not when I2C status bit 0 is 0x04 (as implemented by Adafruit).
See page 14 on the datasheet: https://sensing.honeywell.com/honeywell-sensing-micropressure-board-mount-pressure-mpr-series-datasheet-32332628.pdf

>>> print(mpr.pressure)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/adafruit_mprls.py", line 99, in pressure
    return self._read_data()
  File "/usr/local/lib/python3.7/site-packages/adafruit_mprls.py", line 127, in _read_data
    raise RuntimeError("Integrity failure")
RuntimeError: Integrity failure