### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_mprls.py
+++ b/adafruit_mprls.py
@@ -52,9 +52,7 @@ from adafruit_bus_device.i2c_device import I2CDevice
 from digitalio import Direction
 from micropython import const
 
-# pylint: disable=bad-whitespace
 _MPRLS_DEFAULT_ADDR = const(0x18)
-# pylint: enable=bad-whitespace
 
 
 class MPRLS:


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.